### PR TITLE
Add support for multiple vSphere clusters when managed by a single vCenter appliance

### DIFF
--- a/tasks/discover_vm.yml
+++ b/tasks/discover_vm.yml
@@ -1,34 +1,38 @@
 ---
 
 - name: list registered vcenters
-  uri: 
+  uri:
     url: "{{ act_api_info }}/lshost?filtervalue=hosttype=vcenter&sessionid={{ act_sessionid }}"
     validate_certs: no
   register: lshost
+  check_mode: no
 
-- name: discover clusters 
+- name: discover clusters
   uri:
     url: "{{ act_api_task }}/vmdiscovery?discoverclusters&host={{ item.id }}&sessionid={{ act_sessionid }}"
     validate_certs: no
     method: POST
   register: vmdiscovery
   with_items: "{{ lshost.json.result }}"
+  check_mode: no
 
 - name: discover vms
   uri:
-    url: "{{ act_api_task }}/vmdiscovery?discovervms&host={{ item.item.id }}&cluster={{ item.json.result[0].name }}&sessionid={{ act_sessionid}}"
+    url: "{{ act_api_task }}/vmdiscovery?discovervms&host={{ item.0.item.id }}&cluster={{ item.1.name }}&sessionid={{ act_sessionid }}"
     validate_certs: no
     method: POST
   register: vmdiscovery_vms
-  with_items: "{{ vmdiscovery.results }}"
+  with_subelements:
+    - "{{ vmdiscovery.results }}"
+    - json.result
+  check_mode: no
 
 - name: add the vms to the appliance
   uri:
-    url: "{{ act_api_task }}/vmdiscovery?addvms&host={{ item.0.item.item.id }}&cluster={{ item.0.item.json.result[0].name }}&vms={{ item.1.vmname }}&sessionid={{ act_sessionid }}"
+    url: "{{ act_api_task }}/vmdiscovery?addvms&host={{ item.0.item.0.item.id }}&cluster={{ item.0.item.1.name }}&vms={{ item.1.vmname }}&sessionid={{ act_sessionid }}"
     validate_certs: no
     method: POST
-  when: item.1.ipaddress == "{{ ansible_host }}"
-  with_subelements: 
+  when: item.1.ipaddress == ansible_host
+  with_subelements:
     - "{{ vmdiscovery_vms.results }}"
     - json.result
-


### PR DESCRIPTION
With hardcoded first element reference in '...json.result[0]...' A VM cannot be discovered/added if it runs on another cluster managed by the same vCenter appliance.

Additional use of 'with_subelements' allows for iterating over all elements in json.result[n-1] and discovering VMs on all clusters managed by the same vCenter.

I also removed some trailing whitespace, added check_mode to help with testing when --check is used and removed redundant quotes from one 'when' line.